### PR TITLE
Update fact.c resolving negative numbers for higher input of 12

### DIFF
--- a/4-linking/fact.c
+++ b/4-linking/fact.c
@@ -1,5 +1,5 @@
 // Returns the factorial of n using recursion
-int fatt(int n)
+double fatt(int n)
 {
   if (n == 1) return 1;
   else return n * fatt(n-1);


### PR DESCRIPTION
When 'n' exceeds 12, the result will become negative due to integer overflow.

The reason for this behavior is that the factorial of numbers grows very quickly, and when it exceeds the maximum representable value for an int data type, an overflow occurs, causing the result to wrap around to negative values.