### PR TITLE
Update main.c resolving negative numbers for higher input of 12

### DIFF
--- a/4-linking/main.c
+++ b/4-linking/main.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-extern int fact(int n);
+extern double fact(int n);
 
 int main(void)
 {


### PR DESCRIPTION
When 'n' exceeds 12, the result will become negative due to integer overflow.

The reason for this behavior is that the factorial of numbers grows very quickly, and when it exceeds the maximum representable value for an int data type, an overflow occurs, causing the result to wrap around to negative values.